### PR TITLE
Changed username for winget workflow and updated it newer version

### DIFF
--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: BeagleSoftware.BeagleEditor
           version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Changed the username in the winget workflow to match the current username the user is using to assure no future issues.

It has also been updated to a newer version to keep up with the latest standards.